### PR TITLE
Update phpstan baseline to ignore specific env call warning

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,7 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Called ''env'' outside of the config directory which returns null when the config is cached, use ''config''\.$#'
+			identifier: larastan.noEnvCallsOutsideOfConfig
+			count: 3
+			path: config/bigquery-eloquent.php


### PR DESCRIPTION
This pull request introduces a configuration update to the static analysis tool by adding a new rule exception in the `phpstan-baseline.neon` file. The change allows certain calls to the `env` function outside the config directory to be ignored during static analysis for a specific file.

Static analysis configuration:

* Added an exception to ignore errors related to calling `env` outside of the config directory in `config/bigquery-eloquent.php`, allowing up to 3 occurrences.