### PR TITLE
Refactor BigQuery integration: add custom builder, update grammar handling, improve table wrapping logic, and refine tests.

### DIFF
--- a/src/Database/Query/Grammars/BigQueryGrammar.php
+++ b/src/Database/Query/Grammars/BigQueryGrammar.php
@@ -20,19 +20,16 @@ class BigQueryGrammar extends MySqlGrammar
      */
     public function wrapTable($table, $prefix = null): float|int|string|Expression
     {
-        $table = ltrim($table, $prefix);
-
-        if (stripos($table, ' as ') !== false) {
-            [$name, $alias] = preg_split('/\s+as\s+/i', $table);
-
-            return $this->wrapFullyQualified($name).' as '.$this->wrap($alias);
+        if ($table instanceof Expression) {
+            return $this->getValue($table);
         }
 
-        if (substr_count($table, '.') >= 2) {
-            return $this->wrapFullyQualified($table);
+        // Skip wrapping if already fully qualified
+        if (str_contains($table, '.')) {
+            return $table;
         }
 
-        return parent::wrapTable($table);
+        return "`{$table}`";
     }
 
     /**

--- a/src/Eloquent/BigQueryBuilder.php
+++ b/src/Eloquent/BigQueryBuilder.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace NomanSheikh\LaravelBigqueryEloquent\Eloquent;
+
+use Illuminate\Database\Eloquent\Builder;
+
+class BigQueryBuilder extends Builder
+{
+    //
+}

--- a/src/Eloquent/BigQueryModel.php
+++ b/src/Eloquent/BigQueryModel.php
@@ -28,4 +28,9 @@ abstract class BigQueryModel extends Model
 
         return $this;
     }
+
+    public function newEloquentBuilder($query): BigQueryBuilder
+    {
+        return new BigQueryBuilder($query);
+    }
 }

--- a/src/LaravelBigqueryEloquentServiceProvider.php
+++ b/src/LaravelBigqueryEloquentServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace NomanSheikh\LaravelBigqueryEloquent;
 
-use NomanSheikh\LaravelBigqueryEloquent\Commands\LaravelBigqueryEloquentCommand;
 use NomanSheikh\LaravelBigqueryEloquent\Database\BigQueryConnection;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;

--- a/tests/BigQueryConnectionTest.php
+++ b/tests/BigQueryConnectionTest.php
@@ -19,5 +19,5 @@ it('grammar wraps fully qualified table', function () {
 
     $wrapped = $method->invoke($grammar, 'my-project.my_dataset.my_table');
 
-    expect($wrapped)->toBe('`my-project.my_dataset.my_table`');
+    expect($wrapped)->toBe('my-project.my_dataset.my_table');
 });


### PR DESCRIPTION
This pull request introduces support for custom Eloquent builders for BigQuery models and refines the table wrapping logic for BigQuery grammar. The most significant changes include adding a `BigQueryBuilder` class, updating `BigQueryModel` to use this builder, and adjusting how table names are wrapped to better handle fully qualified names.

**Eloquent Builder Integration:**
* Added a new `BigQueryBuilder` class that extends Laravel's `Builder`, providing a foundation for custom Eloquent query logic specific to BigQuery. (`src/Eloquent/BigQueryBuilder.php`)
* Updated `BigQueryModel` to override `newEloquentBuilder`, ensuring all queries use the new `BigQueryBuilder`. (`src/Eloquent/BigQueryModel.php`)

**BigQuery Grammar Improvements:**
* Refined the `wrapTable` method in `BigQueryGrammar` to:
  * Return the raw value for `Expression` instances.
  * Skip wrapping for fully qualified table names (containing a dot), returning them as-is.
  * Otherwise, wrap the table name in backticks.
  This change ensures compatibility with BigQuery's table naming conventions and avoids unnecessary quoting. (`src/Database/Query/Grammars/BigQueryGrammar.php`)

**Test Adjustments:**
* Updated tests to reflect the new table wrapping logic, expecting unwrapped fully qualified table names. (`tests/BigQueryConnectionTest.php`)

**Minor Cleanup:**
* Removed an unused import from the service provider for clarity. (`src/LaravelBigqueryEloquentServiceProvider.php`)