### PR TITLE
Enhance query logging in BigQueryConnection with execution time tracking

### DIFF
--- a/src/Database/BigQueryConnection.php
+++ b/src/Database/BigQueryConnection.php
@@ -62,10 +62,12 @@ class BigQueryConnection extends Connection
 
     public function select($query, $bindings = [], $useReadPdo = true): array
     {
-        $this->logQuery($query, $bindings);
+        $start = microtime(true);
 
         $job = $this->client->query($query)->parameters(array_values($bindings));
         $result = $this->client->runQuery($job);
+
+        $this->logQuery($query, $bindings, $this->getElapsedTime($start));
 
         $rows = [];
         foreach ($result as $row) {


### PR DESCRIPTION
This pull request makes a small but important change to the `select` method in `BigQueryConnection`. The change enhances query logging by including the elapsed execution time for each query.

- Improved query logging:
  * Modified the `select` method in `BigQueryConnection` to measure and log the elapsed time for each query execution, providing better insight into query performance.