### PR TITLE
Refactor BigQuery integration: improve identifier wrapping, update JSON handling in grammar, enhance test cases for consistent table/query generation

### DIFF
--- a/src/Database/Query/Grammars/BigQueryGrammar.php
+++ b/src/Database/Query/Grammars/BigQueryGrammar.php
@@ -48,7 +48,7 @@ class BigQueryGrammar extends MySqlGrammar
         return $value;
     }
 
-    public function wrap($value): float|int|string|Expression
+    public function wrap($value, $prefixAlias = false): float|int|string|Expression
     {
         if ($value instanceof Expression) {
             return $this->getValue($value);

--- a/src/Database/Query/Grammars/BigQueryGrammar.php
+++ b/src/Database/Query/Grammars/BigQueryGrammar.php
@@ -32,19 +32,34 @@ class BigQueryGrammar extends MySqlGrammar
         return "`{$table}`";
     }
 
-    /**
-     * Wrap a fully-qualified BigQuery identifier
-     *
-     * Why:
-     * - BigQuery expects the entire string wrapped once in backticks.
-     *   Example: `my-project.my_dataset.my_table`
-     * - This prevents Laravel from splitting on "." incorrectly.
-     */
-    protected function wrapFullyQualified(string $name): string
+    protected function wrapValue($value): string
     {
-        $trim = trim($name, '`');
+        // Don't wrap the wildcard
+        if ($value === '*') {
+            return $value;
+        }
 
-        return '`'.$trim.'`';
+        // Do not backtick aliases or normal identifiers
+        // unless they contain special chars (like - or space)
+        if (preg_match('/[^A-Za-z0-9_]/', $value)) {
+            return "`{$value}`";
+        }
+
+        return $value;
+    }
+
+    public function wrap($value): float|int|string|Expression
+    {
+        if ($value instanceof Expression) {
+            return $this->getValue($value);
+        }
+
+        // Example: "alias.column" → leave as-is, don’t turn into `alias`.`column`
+        if (str_contains($value, '.')) {
+            return $value;
+        }
+
+        return $this->wrapValue($value);
     }
 
     /**

--- a/src/Eloquent/BigQueryModel.php
+++ b/src/Eloquent/BigQueryModel.php
@@ -19,7 +19,7 @@ abstract class BigQueryModel extends Model
         $dataset = $this->dataset ?? config("database.connections.{$connName}.dataset");
         $project = config("database.connections.{$connName}.project_id");
 
-        return "{$project}.{$dataset}.{$table}";
+        return "`{$project}.{$dataset}.{$table}`";
     }
 
     public function setDataset(string $dataset): static

--- a/tests/BigQueryGrammarTest.php
+++ b/tests/BigQueryGrammarTest.php
@@ -10,13 +10,13 @@ it('wraps JSON selectors using JSON_VALUE for scalars', function () {
 
     // Single-level JSON path
     $sql = $method->invoke($grammar, 'payload->user_id');
-    expect($sql)->toBe("JSON_VALUE(`payload`, '$.user_id')");
+    expect($sql)->toBe("JSON_VALUE(payload, '$.user_id')");
 
     // Nested JSON path
     $sqlNested = $method->invoke($grammar, 'payload->user->id');
-    expect($sqlNested)->toBe("JSON_VALUE(`payload`, '$.user.id')");
+    expect($sqlNested)->toBe("JSON_VALUE(payload, '$.user.id')");
 
     // Column without JSON path
     $sqlColumn = $method->invoke($grammar, 'payload');
-    expect($sqlColumn)->toBe('`payload`');
+    expect($sqlColumn)->toBe('payload');
 });


### PR DESCRIPTION
This pull request updates the way BigQuery table and column identifiers are wrapped in backticks, ensuring compatibility with BigQuery's requirements and improving consistency across the codebase. The changes also update tests to reflect the new identifier formatting and add a new test for SQL generation.

**BigQuery identifier wrapping improvements:**

* Refactored `BigQueryGrammar` to introduce a new `wrapValue` method that only wraps identifiers in backticks if they contain special characters, and updated the `wrap` method to prevent double-wrapping or incorrect splitting of identifiers with dots.
* Updated `BigQueryModel::getTable()` to always return the fully qualified table name wrapped in backticks, matching BigQuery's expectations.

**Test updates and additions:**

* Updated `BigQueryGrammarTest` to expect column names without backticks when used in JSON path expressions, reflecting the new wrapping logic.
* Updated `BigQueryModelTest` to expect fully qualified table names wrapped in backticks, and added a new test to verify correct SQL generation for a typical BigQuery query. [[1]](diffhunk://#diff-8e88ade05b924b5735292ed1e73f349d6c81a556b3be01b6d3091dd0fa253289L12-R12) [[2]](diffhunk://#diff-8e88ade05b924b5735292ed1e73f349d6c81a556b3be01b6d3091dd0fa253289L21-R21) [[3]](diffhunk://#diff-8e88ade05b924b5735292ed1e73f349d6c81a556b3be01b6d3091dd0fa253289L32-R47)